### PR TITLE
Bump minimist, mkdirp and karma

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "idbstorage",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -62,12 +62,6 @@
                     "requires": {
                         "minimist": "^1.2.0"
                     }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.2",
@@ -299,15 +293,13 @@
             "requires": {
                 "exec-sh": "^0.3.2",
                 "minimist": "^1.2.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
             }
+        },
+        "@colors/colors": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+            "dev": true
         },
         "@doist/prettier-config": {
             "version": "3.0.5",
@@ -975,6 +967,12 @@
                 "type-detect": "4.0.8"
             }
         },
+        "@socket.io/component-emitter": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+            "dev": true
+        },
         "@types/babel__core": {
             "version": "7.1.6",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -1022,6 +1020,21 @@
             "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
             "dev": true
         },
+        "@types/cookie": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+            "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+            "dev": true
+        },
+        "@types/cors": {
+            "version": "2.8.13",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+            "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1046,6 +1059,12 @@
                 "@types/istanbul-lib-coverage": "*",
                 "@types/istanbul-lib-report": "*"
             }
+        },
+        "@types/node": {
+            "version": "18.14.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.4.tgz",
+            "integrity": "sha512-VhCw7I7qO2X49+jaKcAUwi3rR+hbxT5VcYF493+Z5kMLI0DL568b7JI4IDJaxWFH0D/xwmGJNoXisyX+w7GH/g==",
+            "dev": true
         },
         "@types/stack-utils": {
             "version": "1.0.1",
@@ -1085,13 +1104,30 @@
             "dev": true
         },
         "accepts": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.24",
-                "negotiator": "0.6.2"
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.52.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+                    "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.35",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+                    "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "1.52.0"
+                    }
+                }
             }
         },
         "acorn": {
@@ -1149,12 +1185,6 @@
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
             "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
-            "dev": true
-        },
-        "after": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-            "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
             "dev": true
         },
         "ajv": {
@@ -1266,12 +1296,6 @@
             "dev": true,
             "optional": true
         },
-        "arraybuffer.slice": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-            "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
-            "dev": true
-        },
         "asn1": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -1336,27 +1360,12 @@
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
         },
-        "async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.17.14"
-            }
-        },
         "async-each": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
             "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true,
             "optional": true
-        },
-        "async-limiter": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-            "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-            "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
@@ -2149,12 +2158,6 @@
             "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
             "dev": true
         },
-        "backo2": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-            "dev": true
-        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -2228,12 +2231,6 @@
                 }
             }
         },
-        "base64-arraybuffer": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
-            "dev": true
-        },
         "base64-arraybuffer-es6": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.5.0.tgz",
@@ -2247,9 +2244,9 @@
             "dev": true
         },
         "base64id": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-            "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
             "dev": true
         },
         "bcrypt-pbkdf": {
@@ -2259,15 +2256,6 @@
             "dev": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
-            }
-        },
-        "better-assert": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-            "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-            "dev": true,
-            "requires": {
-                "callsite": "1.0.0"
             }
         },
         "binary-extensions": {
@@ -2287,18 +2275,6 @@
                 "file-uri-to-path": "1.0.0"
             }
         },
-        "blob": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
-            "dev": true
-        },
-        "bluebird": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "dev": true
-        },
         "bn.js": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -2306,28 +2282,33 @@
             "dev": true
         },
         "body-parser": {
-            "version": "1.19.0",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
+            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
             "dev": true,
             "requires": {
-                "bytes": "3.1.0",
-                "content-type": "~1.0.4",
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "1.7.2",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
-                "on-finished": "~2.3.0",
-                "qs": "6.7.0",
-                "raw-body": "2.4.0",
-                "type-is": "~1.6.17"
+                "on-finished": "2.4.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
             },
             "dependencies": {
                 "qs": {
-                    "version": "6.7.0",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-                    "dev": true
+                    "version": "6.11.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+                    "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+                    "dev": true,
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
                 }
             }
         },
@@ -2563,28 +2544,6 @@
                 "ieee754": "^1.1.4"
             }
         },
-        "buffer-alloc": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-            "dev": true,
-            "requires": {
-                "buffer-alloc-unsafe": "^1.1.0",
-                "buffer-fill": "^1.0.0"
-            }
-        },
-        "buffer-alloc-unsafe": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "dev": true
-        },
-        "buffer-fill": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-            "dev": true
-        },
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2604,9 +2563,9 @@
             "dev": true
         },
         "bytes": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
             "dev": true
         },
         "cache-base": {
@@ -2640,6 +2599,16 @@
             "integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
             "dev": true
         },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
         "caller-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2648,12 +2617,6 @@
             "requires": {
                 "callsites": "^0.2.0"
             }
-        },
-        "callsite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-            "dev": true
         },
         "callsites": {
             "version": "0.2.0",
@@ -2873,12 +2836,6 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
-        "colors": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-            "dev": true
-        },
         "combine-source-map": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
@@ -2914,22 +2871,10 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
-        "component-bind": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-            "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
-            "dev": true
-        },
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
             "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-            "dev": true
-        },
-        "component-inherit": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-            "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
             "dev": true
         },
         "concat-map": {
@@ -3005,9 +2950,9 @@
             "dev": true
         },
         "content-type": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-            "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "dev": true
         },
         "convert-source-map": {
@@ -3020,9 +2965,9 @@
             }
         },
         "cookie": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
             "dev": true
         },
         "copy-descriptor": {
@@ -3042,6 +2987,16 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
+        },
+        "cors": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4",
+                "vary": "^1"
+            }
         },
         "create-ecdh": {
             "version": "4.0.3",
@@ -3136,7 +3091,7 @@
         "custom-event": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
-            "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+            "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
             "dev": true
         },
         "dashdash": {
@@ -3160,9 +3115,9 @@
             }
         },
         "date-format": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
-            "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+            "version": "4.0.14",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+            "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
             "dev": true
         },
         "date-now": {
@@ -3273,9 +3228,9 @@
             "dev": true
         },
         "depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "dev": true
         },
         "deps-sort": {
@@ -3299,6 +3254,12 @@
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
             }
+        },
+        "destroy": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "dev": true
         },
         "detect-indent": {
             "version": "4.0.0",
@@ -3324,20 +3285,12 @@
                 "acorn-node": "^1.3.0",
                 "defined": "^1.0.0",
                 "minimist": "^1.1.1"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
             }
         },
         "di": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
-            "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+            "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
             "dev": true
         },
         "diff-sequences": {
@@ -3369,7 +3322,7 @@
         "dom-serialize": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
-            "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+            "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
             "dev": true,
             "requires": {
                 "custom-event": "~1.0.0",
@@ -3415,7 +3368,7 @@
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true
         },
         "electron-to-chromium": {
@@ -3448,7 +3401,7 @@
         "encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
             "dev": true
         },
         "end-of-stream": {
@@ -3461,99 +3414,56 @@
             }
         },
         "engine.io": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.1.tgz",
-            "integrity": "sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.1.tgz",
+            "integrity": "sha512-JFYQurD/nbsA5BSPmbaOSLa3tSVj8L6o4srSwXXY3NqE+gGUNmmPTbhn8tjzcCtSqhFgIeqef81ngny8JM25hw==",
             "dev": true,
             "requires": {
+                "@types/cookie": "^0.4.1",
+                "@types/cors": "^2.8.12",
+                "@types/node": ">=10.0.0",
                 "accepts": "~1.3.4",
-                "base64id": "1.0.0",
-                "cookie": "0.3.1",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.0",
-                "ws": "~3.3.1"
+                "base64id": "2.0.0",
+                "cookie": "~0.4.1",
+                "cors": "~2.8.5",
+                "debug": "~4.3.1",
+                "engine.io-parser": "~5.0.3",
+                "ws": "~8.11.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.2"
                     }
                 },
-                "ws": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-                    "dev": true,
-                    "requires": {
-                        "async-limiter": "~1.0.0",
-                        "safe-buffer": "~5.1.0",
-                        "ultron": "~1.1.0"
-                    }
-                }
-            }
-        },
-        "engine.io-client": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-            "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
-            "dev": true,
-            "requires": {
-                "component-emitter": "1.2.1",
-                "component-inherit": "0.0.3",
-                "debug": "~3.1.0",
-                "engine.io-parser": "~2.1.1",
-                "has-cors": "1.1.0",
-                "indexof": "0.0.1",
-                "parseqs": "0.0.5",
-                "parseuri": "0.0.5",
-                "ws": "~3.3.1",
-                "xmlhttprequest-ssl": "~1.5.4",
-                "yeast": "0.1.2"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 },
                 "ws": {
-                    "version": "3.3.3",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-                    "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-                    "dev": true,
-                    "requires": {
-                        "async-limiter": "~1.0.0",
-                        "safe-buffer": "~5.1.0",
-                        "ultron": "~1.1.0"
-                    }
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+                    "dev": true
                 }
             }
         },
         "engine.io-parser": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
-            "integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
-            "dev": true,
-            "requires": {
-                "after": "0.8.2",
-                "arraybuffer.slice": "~0.0.7",
-                "base64-arraybuffer": "0.1.5",
-                "blob": "0.0.5",
-                "has-binary2": "~1.0.2"
-            }
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
+            "integrity": "sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==",
+            "dev": true
         },
         "ent": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
-            "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+            "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
             "dev": true
         },
         "es-abstract": {
@@ -3586,10 +3496,16 @@
                 "is-symbol": "^1.0.2"
             }
         },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "dev": true
         },
         "escape-string-regexp": {
@@ -3825,9 +3741,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-            "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
         },
         "events": {
@@ -4100,6 +4016,23 @@
                 "parseurl": "~1.3.3",
                 "statuses": "~1.5.0",
                 "unpipe": "~1.0.0"
+            },
+            "dependencies": {
+                "on-finished": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                    "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+                    "dev": true,
+                    "requires": {
+                        "ee-first": "1.1.1"
+                    }
+                },
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+                    "dev": true
+                }
             }
         },
         "find-up": {
@@ -4125,15 +4058,15 @@
             }
         },
         "flatted": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
-            "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+            "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.14.7",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+            "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
             "dev": true
         },
         "for-in": {
@@ -4188,14 +4121,22 @@
             }
         },
         "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
+                "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
                 "universalify": "^0.1.0"
+            },
+            "dependencies": {
+                "graceful-fs": {
+                    "version": "4.2.10",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+                    "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+                    "dev": true
+                }
             }
         },
         "fs-readdir-recursive": {
@@ -4438,12 +4379,6 @@
                         "brace-expansion": "^1.1.7"
                     }
                 },
-                "minimist": {
-                    "version": "0.0.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "minipass": {
                     "version": "2.9.0",
                     "bundled": true,
@@ -4461,15 +4396,6 @@
                     "optional": true,
                     "requires": {
                         "minipass": "^2.9.0"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "minimist": "0.0.8"
                     }
                 },
                 "ms": {
@@ -4619,14 +4545,6 @@
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
                     }
                 },
                 "readable-stream": {
@@ -4798,6 +4716,25 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
+        "get-intrinsic": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+            "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.3"
+            },
+            "dependencies": {
+                "has-symbols": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                    "dev": true
+                }
+            }
+        },
         "get-stdin": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
@@ -4942,29 +4879,6 @@
                 "ansi-regex": "^2.0.0"
             }
         },
-        "has-binary2": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-            "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-            "dev": true,
-            "requires": {
-                "isarray": "2.0.1"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
-                    "dev": true
-                }
-            }
-        },
-        "has-cors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-            "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-            "dev": true
-        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -5100,22 +5014,30 @@
             "dev": true
         },
         "http-errors": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "dev": true,
             "requires": {
-                "depd": "~1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.1",
-                "statuses": ">= 1.5.0 < 2",
-                "toidentifier": "1.0.0"
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                    "dev": true
+                }
             }
         },
         "http-proxy": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-            "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
             "dev": true,
             "requires": {
                 "eventemitter3": "^4.0.0",
@@ -5567,13 +5489,10 @@
             "dev": true
         },
         "isbinaryfile": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-            "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-            "dev": true,
-            "requires": {
-                "buffer-alloc": "^1.2.0"
-            }
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+            "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -7281,7 +7200,7 @@
         "jsonfile": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
@@ -7312,43 +7231,56 @@
             }
         },
         "karma": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/karma/-/karma-4.4.1.tgz",
-            "integrity": "sha512-L5SIaXEYqzrh6b1wqYC42tNsFMx2PWuxky84pK9coK09MvmL7mxii3G3bZBh/0rvD27lqDd0le9jyhzvwif73A==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.1.tgz",
+            "integrity": "sha512-Cj57NKOskK7wtFWSlMvZf459iX+kpYIPXmkNUzP2WAFcA7nhr/ALn5R7sw3w+1udFDcpMx/tuB8d5amgm3ijaA==",
             "dev": true,
             "requires": {
-                "bluebird": "^3.3.0",
-                "body-parser": "^1.16.1",
+                "@colors/colors": "1.5.0",
+                "body-parser": "^1.19.0",
                 "braces": "^3.0.2",
-                "chokidar": "^3.0.0",
-                "colors": "^1.1.0",
-                "connect": "^3.6.0",
+                "chokidar": "^3.5.1",
+                "connect": "^3.7.0",
                 "di": "^0.0.1",
-                "dom-serialize": "^2.2.0",
-                "flatted": "^2.0.0",
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "http-proxy": "^1.13.0",
-                "isbinaryfile": "^3.0.0",
-                "lodash": "^4.17.14",
-                "log4js": "^4.0.0",
-                "mime": "^2.3.1",
-                "minimatch": "^3.0.2",
-                "optimist": "^0.6.1",
-                "qjobs": "^1.1.4",
-                "range-parser": "^1.2.0",
-                "rimraf": "^2.6.0",
-                "safe-buffer": "^5.0.1",
-                "socket.io": "2.1.1",
+                "dom-serialize": "^2.2.1",
+                "glob": "^7.1.7",
+                "graceful-fs": "^4.2.6",
+                "http-proxy": "^1.18.1",
+                "isbinaryfile": "^4.0.8",
+                "lodash": "^4.17.21",
+                "log4js": "^6.4.1",
+                "mime": "^2.5.2",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.5",
+                "qjobs": "^1.2.0",
+                "range-parser": "^1.2.1",
+                "rimraf": "^3.0.2",
+                "socket.io": "^4.4.1",
                 "source-map": "^0.6.1",
-                "tmp": "0.0.33",
-                "useragent": "2.3.0"
+                "tmp": "^0.2.1",
+                "ua-parser-js": "^0.7.30",
+                "yargs": "^16.1.1"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
                 "anymatch": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+                    "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
                     "dev": true,
                     "requires": {
                         "normalize-path": "^3.0.0",
@@ -7356,9 +7288,9 @@
                     }
                 },
                 "binary-extensions": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-                    "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+                    "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
                     "dev": true
                 },
                 "braces": {
@@ -7371,20 +7303,46 @@
                     }
                 },
                 "chokidar": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-                    "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+                    "version": "3.5.3",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+                    "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "~3.1.1",
+                        "anymatch": "~3.1.2",
                         "braces": "~3.0.2",
-                        "fsevents": "~2.1.2",
-                        "glob-parent": "~5.1.0",
+                        "fsevents": "~2.3.2",
+                        "glob-parent": "~5.1.2",
                         "is-binary-path": "~2.1.0",
                         "is-glob": "~4.0.1",
                         "normalize-path": "~3.0.0",
-                        "readdirp": "~3.3.0"
+                        "readdirp": "~3.6.0"
                     }
+                },
+                "cliui": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^7.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
                 },
                 "fill-range": {
                     "version": "7.0.1",
@@ -7396,20 +7354,51 @@
                     }
                 },
                 "fsevents": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-                    "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
                     "dev": true,
                     "optional": true
                 },
+                "glob": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.1.1",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "minimatch": {
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                            "dev": true,
+                            "requires": {
+                                "brace-expansion": "^1.1.7"
+                            }
+                        }
+                    }
+                },
                 "glob-parent": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-                    "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
                     "dev": true,
                     "requires": {
                         "is-glob": "^4.0.1"
                     }
+                },
+                "graceful-fs": {
+                    "version": "4.2.10",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+                    "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+                    "dev": true
                 },
                 "is-binary-path": {
                     "version": "2.1.0",
@@ -7423,13 +7412,19 @@
                 "is-extglob": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-                    "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+                    "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                     "dev": true
                 },
                 "is-glob": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+                    "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
                     "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
@@ -7441,6 +7436,12 @@
                     "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
                     "dev": true
                 },
+                "lodash": {
+                    "version": "4.17.21",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+                    "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+                    "dev": true
+                },
                 "normalize-path": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -7448,12 +7449,21 @@
                     "dev": true
                 },
                 "readdirp": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-                    "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+                    "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
                     "dev": true,
                     "requires": {
-                        "picomatch": "^2.0.7"
+                        "picomatch": "^2.2.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
                     }
                 },
                 "source-map": {
@@ -7461,6 +7471,35 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
+                },
+                "tmp": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+                    "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+                    "dev": true,
+                    "requires": {
+                        "rimraf": "^3.0.0"
+                    }
                 },
                 "to-regex-range": {
                     "version": "5.0.1",
@@ -7470,6 +7509,44 @@
                     "requires": {
                         "is-number": "^7.0.0"
                     }
+                },
+                "wrap-ansi": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "5.0.8",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "16.2.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.0",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^20.2.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+                    "dev": true
                 }
             }
         },
@@ -7570,25 +7647,25 @@
             "dev": true
         },
         "log4js": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.5.1.tgz",
-            "integrity": "sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==",
+            "version": "6.8.0",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.8.0.tgz",
+            "integrity": "sha512-g+V8gZyurIexrOvWQ+AcZsIvuK/lBnx2argejZxL4gVZ4Hq02kUYH6WZOnqxgBml+zzQZYdaEoTN84B6Hzm8Fg==",
             "dev": true,
             "requires": {
-                "date-format": "^2.0.0",
-                "debug": "^4.1.1",
-                "flatted": "^2.0.0",
-                "rfdc": "^1.1.4",
-                "streamroller": "^1.0.6"
+                "date-format": "^4.0.14",
+                "debug": "^4.3.4",
+                "flatted": "^3.2.7",
+                "rfdc": "^1.3.0",
+                "streamroller": "^3.1.5"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -7689,7 +7766,7 @@
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
             "dev": true
         },
         "merge-stream": {
@@ -7731,9 +7808,9 @@
             }
         },
         "mime": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
             "dev": true
         },
         "mime-db": {
@@ -7779,9 +7856,9 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true
         },
         "mixin-deep": {
@@ -7806,12 +7883,12 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+            "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.6"
             }
         },
         "module-deps": {
@@ -7916,9 +7993,9 @@
             "dev": true
         },
         "negotiator": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "dev": true
         },
         "nice-try": {
@@ -8008,12 +8085,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "dev": true
-        },
-        "object-component": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-            "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
             "dev": true
         },
         "object-copy": {
@@ -8118,9 +8189,9 @@
             }
         },
         "on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
             "requires": {
                 "ee-first": "1.1.1"
@@ -8142,24 +8213,6 @@
             "dev": true,
             "requires": {
                 "mimic-fn": "^1.0.0"
-            }
-        },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "dev": true,
-            "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-                    "dev": true
-                }
             }
         },
         "optionator": {
@@ -8287,24 +8340,6 @@
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
             "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
             "dev": true
-        },
-        "parseqs": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-            "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-            "dev": true,
-            "requires": {
-                "better-assert": "~1.0.0"
-            }
-        },
-        "parseuri": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-            "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-            "dev": true,
-            "requires": {
-                "better-assert": "~1.0.0"
-            }
         },
         "parseurl": {
             "version": "1.3.3",
@@ -8633,13 +8668,13 @@
             "dev": true
         },
         "raw-body": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+            "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
             "dev": true,
             "requires": {
-                "bytes": "3.1.0",
-                "http-errors": "1.7.2",
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             }
@@ -9228,7 +9263,7 @@
         "requires-port": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true
         },
         "resolve": {
@@ -9286,9 +9321,9 @@
             "dev": true
         },
         "rfdc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.4.tgz",
-            "integrity": "sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
             "dev": true
         },
         "rimraf": {
@@ -9661,12 +9696,6 @@
                         "snapdragon": "^0.8.1",
                         "to-regex": "^3.0.2"
                     }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
                 }
             }
         },
@@ -9721,9 +9750,9 @@
             "dev": true
         },
         "setprototypeof": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
             "dev": true
         },
         "sha.js": {
@@ -9779,6 +9808,25 @@
             "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
             "dev": true,
             "optional": true
+        },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            },
+            "dependencies": {
+                "object-inspect": {
+                    "version": "1.12.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+                    "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+                    "dev": true
+                }
+            }
         },
         "signal-exit": {
             "version": "3.0.2",
@@ -9922,93 +9970,76 @@
             }
         },
         "socket.io": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
-            "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
+            "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
             "dev": true,
             "requires": {
-                "debug": "~3.1.0",
-                "engine.io": "~3.2.0",
-                "has-binary2": "~1.0.2",
-                "socket.io-adapter": "~1.1.0",
-                "socket.io-client": "2.1.1",
-                "socket.io-parser": "~3.2.0"
+                "accepts": "~1.3.4",
+                "base64id": "~2.0.0",
+                "debug": "~4.3.2",
+                "engine.io": "~6.4.1",
+                "socket.io-adapter": "~2.5.2",
+                "socket.io-parser": "~4.2.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.2"
                     }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 }
             }
         },
         "socket.io-adapter": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
-            "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
-            "dev": true
-        },
-        "socket.io-client": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-            "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
+            "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
             "dev": true,
             "requires": {
-                "backo2": "1.0.2",
-                "base64-arraybuffer": "0.1.5",
-                "component-bind": "1.0.0",
-                "component-emitter": "1.2.1",
-                "debug": "~3.1.0",
-                "engine.io-client": "~3.2.0",
-                "has-binary2": "~1.0.2",
-                "has-cors": "1.1.0",
-                "indexof": "0.0.1",
-                "object-component": "0.0.3",
-                "parseqs": "0.0.5",
-                "parseuri": "0.0.5",
-                "socket.io-parser": "~3.2.0",
-                "to-array": "0.1.4"
+                "ws": "~8.11.0"
             },
             "dependencies": {
-                "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
+                "ws": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+                    "dev": true
                 }
             }
         },
         "socket.io-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-            "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
+            "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
             "dev": true,
             "requires": {
-                "component-emitter": "1.2.1",
-                "debug": "~3.1.0",
-                "isarray": "2.0.1"
+                "@socket.io/component-emitter": "~3.1.0",
+                "debug": "~4.3.1"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "2.1.2"
                     }
                 },
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
                     "dev": true
                 }
             }
@@ -10107,9 +10138,9 @@
             }
         },
         "statuses": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true
         },
         "stealthy-require": {
@@ -10162,25 +10193,23 @@
             }
         },
         "streamroller": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-1.0.6.tgz",
-            "integrity": "sha512-3QC47Mhv3/aZNFpDDVO44qQb9gwB9QggMEE0sQmkTAwBVYdBRWISdsywlkfm5II1Q5y/pmrHflti/IgmIzdDBg==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+            "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
             "dev": true,
             "requires": {
-                "async": "^2.6.2",
-                "date-format": "^2.0.0",
-                "debug": "^3.2.6",
-                "fs-extra": "^7.0.1",
-                "lodash": "^4.17.14"
+                "date-format": "^4.0.14",
+                "debug": "^4.3.4",
+                "fs-extra": "^8.1.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -10314,14 +10343,6 @@
             "dev": true,
             "requires": {
                 "minimist": "^1.1.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
             }
         },
         "supports-color": {
@@ -10517,12 +10538,6 @@
             "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
             "dev": true
         },
-        "to-array": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-            "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
-            "dev": true
-        },
         "to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -10578,9 +10593,9 @@
             }
         },
         "toidentifier": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "dev": true
         },
         "tough-cookie": {
@@ -10709,10 +10724,10 @@
                 "whatwg-url": "7.1.0"
             }
         },
-        "ultron": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+        "ua-parser-js": {
+            "version": "0.7.33",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+            "integrity": "sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==",
             "dev": true
         },
         "umd": {
@@ -10754,7 +10769,7 @@
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true
         },
         "unset-value": {
@@ -10856,16 +10871,6 @@
             "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
             "dev": true
         },
-        "useragent": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-            "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
-            "dev": true,
-            "requires": {
-                "lru-cache": "4.1.x",
-                "tmp": "0.0.x"
-            }
-        },
         "util": {
             "version": "0.10.4",
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -10896,7 +10901,7 @@
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
             "dev": true
         },
         "uuid": {
@@ -10933,6 +10938,12 @@
                 "user-home": "^1.1.1"
             }
         },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true
+        },
         "verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -10956,7 +10967,7 @@
         "void-elements": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-            "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+            "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
             "dev": true
         },
         "w3c-hr-time": {
@@ -11156,12 +11167,6 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
         },
-        "xmlhttprequest-ssl": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-            "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
-            "dev": true
-        },
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -11242,12 +11247,6 @@
                 "camelcase": "^5.0.0",
                 "decamelize": "^1.2.0"
             }
-        },
-        "yeast": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-            "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
-            "dev": true
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "fake-indexeddb": "^3.0.0",
         "jasmine-core": "^3.5.0",
         "jest": "^25.1.0",
-        "karma": "^4.4.1",
+        "karma": "^6.4.1",
         "karma-chrome-launcher": "^2.2.0",
         "karma-jasmine": "^2.0.1"
     },


### PR DESCRIPTION
Bumps [minimist](https://github.com/minimistjs/minimist) to 1.2.8 and updates ancestor dependencies [minimist](https://github.com/minimistjs/minimist), [mkdirp](https://github.com/isaacs/node-mkdirp) and [karma](https://github.com/karma-runner/karma). These dependencies need to be updated together.


Updates `minimist` from 1.2.0 to 1.2.8
- [Release notes](https://github.com/minimistjs/minimist/releases)
- [Changelog](https://github.com/minimistjs/minimist/blob/main/CHANGELOG.md)
- [Commits](https://github.com/minimistjs/minimist/compare/v1.2.0...v1.2.8)

Updates `mkdirp` from 0.5.1 to 0.5.6
- [Release notes](https://github.com/isaacs/node-mkdirp/releases)
- [Changelog](https://github.com/isaacs/node-mkdirp/blob/main/CHANGELOG.md)
- [Commits](https://github.com/isaacs/node-mkdirp/compare/0.5.1...v0.5.6)

Updates `karma` from 4.4.1 to 6.4.1
- [Release notes](https://github.com/karma-runner/karma/releases)
- [Changelog](https://github.com/karma-runner/karma/blob/master/CHANGELOG.md)
- [Commits](https://github.com/karma-runner/karma/compare/v4.4.1...v6.4.1)

---
updated-dependencies:
- dependency-name: minimist dependency-type: indirect
- dependency-name: mkdirp dependency-type: indirect
- dependency-name: karma dependency-type: direct:development ...